### PR TITLE
Fix issue pom.xml that breaks asciidoc generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,11 @@
                         <artifactId>asciidoctorj-pdf</artifactId>
                         <version>1.5.0-alpha.10.1</version>
                     </dependency>
+                    <dependency>
+                        <groupId>org.jruby</groupId>
+                        <artifactId>jruby-complete</artifactId>
+                        <version>1.7.21</version>
+                    </dependency>
                 </dependencies>
                 <!-- Configure generic document generation settings -->
                 <configuration>


### PR DESCRIPTION
Added in a dependency for org.jruby

Fixes #10