### PR TITLE
upgrade libs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,8 @@
         <asciidoctor.pdf.output.directory>${project.build.directory}/asciidoc/pdf</asciidoctor.pdf.output.directory>
 
         <swagger.input>${swagger.output.dir}/swagger.json</swagger.input>
+        <jackson.version>2.9.6</jackson.version>
+        <springfox.version>2.9.2</springfox.version>
     </properties>
 
     <pluginRepositories>
@@ -72,38 +74,38 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>1.5.6</version>
+            <version>1.5.20</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>26.0-jre</version>
         </dependency>
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>4.5.1</version>
+            <version>5.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-smile</artifactId>
-            <version>2.6.5</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
-            <version>2.6.5</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
-            <version>2.4.0</version>
+            <version>${springfox.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-bean-validators</artifactId>
-            <version>2.4.0</version>
+            <version>${springfox.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -113,7 +115,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-staticdocs</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.restdocs</groupId>
@@ -122,13 +124,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jsonSchema</artifactId>
-            <version>2.6.5</version>
+            <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.github.robwin</groupId>
             <artifactId>assertj-swagger</artifactId>
-            <version>0.2.0</version>
+            <version>0.8.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -214,13 +216,13 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>1.5.3</version>
+                <version>1.5.6</version>
                 <!-- Include Asciidoctor PDF for pdf generation -->
                 <dependencies>
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-pdf</artifactId>
-                        <version>1.5.0-alpha.10.1</version>
+                        <version>1.5.0-alpha.16</version>
                     </dependency>
                     <dependency>
                         <groupId>org.jruby</groupId>
@@ -277,7 +279,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -308,7 +310,7 @@
             <!-- copy the generated documents -->
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.7</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>copy-resources</id>


### PR DESCRIPTION
## Upgrade libs
- swagger-annotations 1.5.6 -> 1.5.20
- guava 18.0 -> 26.0-jre
- logstash-logback-encoder 4.5.1 -> 5.1
- jackson-dataformat-smile 2.6.5 -> 2.9.6
- jackson-module-afterburner 2.6.5 -> 2.9.6
- springfox-swagger2 2.4.0 -> 2.9.2
- springfox-bean-validators 2.4.0 -> 2.9.2
- springfox-staticdocs 2.4.0 -> 2.6.1
- jackson-module-jsonSchema 2.6.5 -> 2.9.6
- assertj-swagger 0.2.0 -> 0.8.1
- asciidoctor-maven-plugin 1.5.3 -> 1.5.6
- asciidoctorj-pdf 1.5.0-alpha.10.1 -> 1.5.0-alpha.16
- maven-jar-plugin 2.4 -> 3.1.0
- maven-resources-plugin 2.4 -> 3.1.0